### PR TITLE
Replace dots with slashes in group id

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var publish_file = function (artifactory, repo_key, project, file, force_upload)
     if (file.indexOf('pom') > -1) { basename = project.artifact_id + '-' + project.version + '.pom'; } 
 
     winston.info('Uploading ' + file + ' as ' + basename + ' into ' + repo_key);
-    return artifactory.uploadFile(repo_key, '/' + project.group_id + '/' + project.artifact_id + '/' + project.version + '/' + basename, file, force_upload)
+    return artifactory.uploadFile(repo_key, '/' + replace_dots(project.group_id) + '/' + project.artifact_id + '/' + project.version + '/' + basename, file, force_upload)
     .then((uploadInfo) => {
 
       winston.info('Upload successful. Available at: ' + uploadInfo.downloadUri)
@@ -99,6 +99,10 @@ var check_params = function (params) {
   });
 }
 
+var replace_dots = function(param){
+  return param.replace(new RegExp('\\.', 'g'),'/');
+}
+
 // Expose public methods for tests
 if(require.main === module) {
   plugin.parse()
@@ -109,6 +113,7 @@ if(require.main === module) {
   module.exports = {
     check_params: check_params,
     expands_files: expands_files,
-    do_upload: do_upload
+    do_upload: do_upload,
+    replace_dots: replace_dots
   }
 }

--- a/test/files/pom.xml
+++ b/test/files/pom.xml
@@ -5,7 +5,7 @@
 
   <modelVersion>4.0.0</modelVersion>
  
-  <groupId>drone</groupId>
+  <groupId>com.example.drone</groupId>
   <artifactId>artifactory</artifactId>
   <version>0</version>
 </project>

--- a/test/index.js
+++ b/test/index.js
@@ -48,7 +48,12 @@ describe('Drone Artifactory', function () {
     it('should read details from a correct pom file', function () {
       var params = {vargs: { url: 'http', pom: 'pom.xml'}, workspace: { path: './test/files' }};
 
-      return expect(arti.check_params(params), 'when fulfilled', 'to satisfy', { vargs: { group_id: 'drone', artifact_id: 'artifactory', version: '0'} });
+      return expect(arti.check_params(params), 'when fulfilled', 'to satisfy', { vargs: { group_id: 'com.example.drone', artifact_id: 'artifactory', version: '0'} });
+    });
+    it('should read details from correct group id, artifact id and version', function () {
+      var params = {vargs: { url: 'http', group_id: 'com.example.drone', artifact_id: 'artifactory', version: '0'}, workspace: { path: './test/files' }};
+
+      return expect(arti.check_params(params), 'when fulfilled', 'to satisfy', { vargs: { group_id: 'com.example.drone', artifact_id: 'artifactory', version: '0'} });
     });
   });
 
@@ -70,10 +75,10 @@ describe('Drone Artifactory', function () {
   describe('#do_upload()', function () {
     it('should publish a pom file with required name', function () {
       var req = nock('http://arti.facto.ry')
-                .intercept('/artifactory/libs-release-local/drone/arti/2.0/arti-2.0.pom', 'HEAD')
+                .intercept('/artifactory/libs-release-local/com/example/drone/arti/2.0/arti-2.0.pom', 'HEAD')
                 .basicAuth({ user: 'admin', pass: 'admin' })
                 .reply(404)
-                .put('/artifactory/libs-release-local/drone/arti/2.0/arti-2.0.pom')
+                .put('/artifactory/libs-release-local/com/example/drone/arti/2.0/arti-2.0.pom')
                 .basicAuth({ user: 'admin', pass: 'admin' })
                 .reply(201, {});
 
@@ -81,7 +86,7 @@ describe('Drone Artifactory', function () {
         vargs: {
           url: 'http://arti.facto.ry',
           username: 'admin', password: 'admin',
-          group_id: 'drone', artifact_id: 'arti', version: '2.0',
+          group_id: 'com.example.drone', artifact_id: 'arti', version: '2.0',
           files: ['pom.xml'],
           log_level: 'warn'
         }
@@ -219,6 +224,12 @@ describe('Drone Artifactory', function () {
       }; 
 
       return expect(arti.do_upload(params).then(() => { return req.isDone(); }), 'when fulfilled', 'to equal', true);
+    });
+  });
+
+  describe('#replace_dots()', function () {
+    it('should be able to replace dots', function () {
+      expect(arti.replace_dots('com.example.xyz'), 'to contain', 'com/example/xyz');
     });
   });
 });


### PR DESCRIPTION
## The issue
We noticed that the _drone-artifactory_ plugin was failing to upload artifacts into our Artifactory instance when:
* the artifact was a pom/jar file for a release version (not snapshot) 
* the group id specified was containing dots

The version of Artifactory used is _Pro Power Pack 3.3.0.1 (rev. 30106)_.

To reproduce the issue I have run the _drone-artifactory_ plugin with the following config:
```
node index.js <<EOF
{
    "repo": {
        "clone_url": "git://github.com/drone/drone",
        "owner": "drone",
        "name": "drone",
        "full_name": "drone/drone"
    },
    "system": {
        "link_url": "https://beta.drone.io"
    },
    "build": {
        "number": 22,
        "status": "success",
        "started_at": 1421029603,
        "finished_at": 1421029813,
        "message": "Testing Drone Artifactory",
        "author": "john doe",
        "author_email": "john.doe@gmail.com"
    },
    "workspace": {
        "root": "/drone/src",
        "path": "/Users/johndoe/drone-artifactory"
    },
    "vargs": {
        "url": "http://artifactory:8081",
        "username": "username",
        "password": "password",
        "repo_key": "release-repo",
	"pom": "pom.xml",
	"force_upload": "true",
        "files": [
            "pom.xml",
            "target/snapshot/*.jar"
        ]
    }
}
EOF
```
and the result was:
```
info: Project groupId: net.skyscanner.schemas
info: Project artifactId: schemas
info: Project version: testDrone
info: Uploading /Users/johndoe/drone-artifactory/pom.xml as testDrone.pom into release-repo
info: Uploading /Users/johndoe/drone-artifactory/target/release/testDrone.jar as testDrone.jar into release-repo
error: An error happened while trying to publish the file Users/johndoe/drone-artifactory/pom.xml: HTTP Status Code from server was: 409
```

Same thing happened specifying the group id, artifact id and version explicitly in the configuration:
```
node index.js <<EOF
{
    "repo": {
        "clone_url": "git://github.com/drone/drone",
        "owner": "drone",
        "name": "drone",
        "full_name": "drone/drone"
    },
    "system": {
        "link_url": "https://beta.drone.io"
    },
    "build": {
        "number": 22,
        "status": "success",
        "started_at": 1421029603,
        "finished_at": 1421029813,
        "message": "Testing Drone Artifactory",
        "author": "john doe",
        "author_email": "john.doe@gmail.com"
    },
    "workspace": {
        "root": "/drone/src",
        "path": "/Users/johndoe/drone-artifactory"
    },
    "vargs": {
        "url": "http://artifactory:8081",
        "username": "username",
        "password": "password",
        "repo_key": "release-repo",
	"group_id": "com.example.xyz",
	"artifact_id": "testDrone",
	"version": "1.0",
	"force_upload": "true",
        "files": [
            "pom.xml",
            "target/snapshot/*.jar"
        ]
    }
}
EOF
```

## The proposed solution
The proposed solution is to replace the dots into the group id with slashes.
In this way the upload of both the pom and jar files is succeeding and the files are placed into the right path in Artifactory.