### PR TITLE
Allow Glob paths for filenames

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -14,6 +14,8 @@ You can override the default configuration with the following parameters:
 
 All file paths must be relative to current project sources
 
+File paths are interpreted with [node-glob](https://github.com/isaacs/node-glob#glob-primer) and can contain things such as regex, or directory wildcards(./\*\*/\*.js)
+
 ## Example
 
 The following is a sample configuration in your .drone.yml file:
@@ -29,6 +31,7 @@ publish:
     files: 
       - target/*.jar
       - target/*.war
+      - dist/**/*.min.js
 ```
 
 ## pom.xml deployment

--- a/index.js
+++ b/index.js
@@ -3,20 +3,20 @@ const plugin = new Drone.Plugin();
 
 const ArtifactoryAPI = require('artifactory-api');
 const pomParser = require("pom-parser");
-const shelljs = require("shelljs");
+const glob = require("glob");
 const winston = require("winston");
 
 const btoa = require('btoa');
 const fs = require('fs');
 const path = require('path');
 
-var expands_files = function (path, files) { return [].concat.apply([], files.map((f) => { return shelljs.ls(path + '/' + f); })); }
+var expands_files = function (path, files) { return [].concat.apply([], files.map((f) => { return glob.sync(path + '/' + f); })); }
 
 var publish_file = function (artifactory, repo_key, project, file, force_upload) {
   return new Promise((resolve, reject) => {
     var basename = path.basename(file);
     // If file to publish is a pom file, change name to official Maven requirements
-    if (file.indexOf('pom') > -1) { basename = project.artifact_id + '-' + project.version + '.pom'; } 
+    if (file.indexOf('pom') > -1) { basename = project.artifact_id + '-' + project.version + '.pom'; }
 
     winston.info('Uploading ' + file + ' as ' + basename + ' into ' + repo_key);
     return artifactory.uploadFile(repo_key, '/' + replace_dots(project.group_id) + '/' + project.artifact_id + '/' + project.version + '/' + basename, file, force_upload)

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "artifactory-api": "0.0.3",
     "btoa": "^1.1.2",
     "drone-node": "^1.0.1",
+    "glob": "^7.0.3",
     "pom-parser": "^1.1.0",
-    "shelljs": "^0.5.3",
     "winston": "^2.1.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -70,15 +70,18 @@ describe('Drone Artifactory', function () {
   describe('#expands_files()', function () {
     it('should be able to resolve wildcards', function () {
 
-      expect(arti.expands_files('./test/files', ['*.json']), 'to contain', 'test/files/pom.json');
+      expect(arti.expands_files('./test/files', ['*.json']), 'to contain', './test/files/pom.json');
     });
     it('should be able to resolve a mix of wildcards and files', function () {
 
-      expect(arti.expands_files('./test/files', ['*.xml', 'test.jar']), 'to contain', 'test/files/pom.xml', 'test/files/useless.xml', './test/files/test.jar');
+      expect(arti.expands_files('./test/files', ['*.xml', 'test.jar']), 'to contain', './test/files/pom.xml', './test/files/useless.xml', './test/files/test.jar');
     });
     it('should be able to accept an empty array of files', function () {
 
       expect(arti.expands_files('./test/files', []), 'to be empty');
+    });
+    it('should be able to accept glob paths', function() {
+      expect(arti.expands_files('./test', ['**/*.jar']), 'to contain', './test/files/test.jar');
     });
   });
 
@@ -100,7 +103,7 @@ describe('Drone Artifactory', function () {
           files: ['pom.xml'],
           log_level: 'warn'
         }
-      }; 
+      };
 
       return expect(arti.do_upload(params).then(() => { return req.isDone(); }), 'when fulfilled', 'to equal', true);
     });
@@ -121,7 +124,7 @@ describe('Drone Artifactory', function () {
           files: ['test.jar'],
           log_level: 'warn'
         }
-      }; 
+      };
 
       return expect(arti.do_upload(params).then(() => { return req.isDone(); }), 'when fulfilled', 'to equal', true);
     });
@@ -143,7 +146,7 @@ describe('Drone Artifactory', function () {
           repo_key: 'custom_repo',
           log_level: 'warn'
         }
-      }; 
+      };
 
       return expect(arti.do_upload(params).then(() => { return req.isDone(); }), 'when fulfilled', 'to equal', true);
     });
@@ -164,7 +167,7 @@ describe('Drone Artifactory', function () {
           files: ['test.jar'],
           log_level: 'warn'
         }
-      }; 
+      };
 
       return expect(arti.do_upload(params).then(() => { return req.isDone(); }), 'to be rejected');
     });
@@ -182,7 +185,7 @@ describe('Drone Artifactory', function () {
           files: ['test.jar'],
           log_level: 'warn'
         }
-      }; 
+      };
 
       return expect(arti.do_upload(params).then(() => { return req.isDone(); }), 'to be rejected');
     });
@@ -204,7 +207,7 @@ describe('Drone Artifactory', function () {
           force_upload: true,
           log_level: 'warn'
         }
-      }; 
+      };
 
       return expect(arti.do_upload(params).then(() => { return req.isDone(); }), 'when fulfilled', 'to equal', true);
     });
@@ -231,7 +234,7 @@ describe('Drone Artifactory', function () {
           files: ['pom.xml', 'test.jar'],
           log_level: 'warn'
         }
-      }; 
+      };
 
       return expect(arti.do_upload(params).then(() => { return req.isDone(); }), 'when fulfilled', 'to equal', true);
     });


### PR DESCRIPTION
This commit will remove shelljs in favor of node-glob.

This will allow file descriptions, such as:
./target/app/\*.jar
./target/\*\*/\*.jar
./\*\*/\*.jar

where ** is a glob of any number of directories