### PR TITLE
fix: [CI-19671]: Updating modules to fix vulnerabilities.

### DIFF
--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -35,7 +35,7 @@ pipeline:
                   identifier: Run_1
                   spec:
                     connectorRef: Plugins_Docker_Hub_Connector
-                    image: golang:1.22.7
+                    image: golang:1.25.4
                     shell: Sh
                     command: |-
                       go test -cover ./...
@@ -65,7 +65,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22.7
+                        image: golang:1.25.4
                         shell: Sh
                         command: go build -v -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/linux/amd64/plugin
                       when:
@@ -78,7 +78,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22.7
+                        image: golang:1.25.4
                         shell: Sh
                         command: go build -v -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/linux/amd64/plugin
                       when:
@@ -140,7 +140,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22.7
+                        image: golang:1.25.4
                         shell: Sh
                         command: go build -v -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/linux/arm64/plugin
                       when:
@@ -153,7 +153,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22.7
+                        image: golang:1.25.4
                         shell: Sh
                         command: go build -v -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/linux/arm64/plugin
                       when:
@@ -209,7 +209,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22.7
+                        image: golang:1.25.4
                         shell: Sh
                         command: go build -v -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -222,7 +222,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22.7
+                        image: golang:1.25.4
                         shell: Sh
                         command: go build -v -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -293,7 +293,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22.7
+                        image: golang:1.25.4
                         shell: Sh
                         command: go build -v -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -306,7 +306,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.22.7
+                        image: golang:1.25.4
                         shell: Sh
                         command: go build -v -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -385,7 +385,7 @@ pipeline:
                   identifier: Build_Binaries
                   spec:
                     connectorRef: Plugins_Docker_Hub_Connector
-                    image: golang:1.22.7
+                    image: golang:1.25.4
                     shell: Sh
                     command: |-
                       GOOS=linux   GOARCH=amd64 go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/plugin-linux-amd64

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,12 +1,12 @@
-FROM alpine:3.20 as alpine
+FROM alpine:3.21 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.20
+FROM alpine:3.21
 ENV GODEBUG netdns=go
 ENV CI=true
 
 ARG JRE_VERSION=openjdk17
-ARG GRADLE_VERSION=8.3
+ARG GRADLE_VERSION=8.13
 
 # Copy CA certificates
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
@@ -28,8 +28,8 @@ RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION
     && rm /tmp/gradle.zip \
     && ln -s /opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle
 
-# Install JFrog CLI
-RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.73.2
+# Install JFrog CLI (latest version with security fixes)
+RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.82.0
 RUN mv ./jf /usr/local/bin/jf
 RUN chmod +x /usr/local/bin/jf
 

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,17 +1,17 @@
-FROM arm64v8/alpine:3.20 as alpine
+FROM arm64v8/alpine:3.21 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM arm64v8/alpine:3.20
+FROM arm64v8/alpine:3.21
 ENV GODEBUG netdns=go
 ENV CI=true
 
 ARG JRE_VERSION=openjdk17
-ARG GRADLE_VERSION=8.3
+ARG GRADLE_VERSION=8.13
 
 # Copy CA certificates
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-# Install jfrog cli with version 2.37.3
+# Install JFrog CLI (latest version with security fixes)
 RUN apk add --update \
     bash \
     "$JRE_VERSION" \
@@ -29,7 +29,7 @@ RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION
     && ln -s /opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle
 
 # Install JFrog CLI
-RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.73.2
+RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.82.0
 RUN mv ./jf /usr/local/bin/jf
 RUN chmod +x /usr/local/bin/jf
 

--- a/docker/Dockerfile.windows.amd64.1809
+++ b/docker/Dockerfile.windows.amd64.1809
@@ -5,9 +5,9 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS builder
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set versions
-ENV JDK_VERSION="17.0.8+7"
-ENV MAVEN_VERSION="3.9.4"
-ENV GRADLE_VERSION="8.3"
+ENV JDK_VERSION="17.0.13+11"
+ENV MAVEN_VERSION="3.9.11"
+ENV GRADLE_VERSION="8.13"
 
 # Create necessary directories
 RUN mkdir C:\bin | Out-Null; `
@@ -24,18 +24,18 @@ COPY docker/cert.windows.pem docker/cacert.pem C:\users\ContainerAdministrator\.
 RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     `
     # Download JFrog CLI
-    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.68.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
+    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.82.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
     `
     # Download and install JDK
-    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.8_7.zip" -OutFile "C:\jdk.zip"; `
+    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jdk_x64_windows_hotspot_17.0.13_11.zip" -OutFile "C:\jdk.zip"; `
     Expand-Archive -Path "C:\jdk.zip" -DestinationPath "C:\jdk"; `
     `
     # Download and install Maven
-    Invoke-WebRequest -Uri https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip -OutFile C:\maven.zip; `
+    Invoke-WebRequest -Uri https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip -OutFile C:\maven.zip; `
     Expand-Archive -Path C:\maven.zip -DestinationPath C:\maven; `
     `
     # Download and install Gradle
-    Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.3-bin.zip" -OutFile "C:\gradle.zip"; `
+    Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.13-bin.zip" -OutFile "C:\gradle.zip"; `
     Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"
 
 # Final image using PowerShell Nanoserver - much smaller base image with PowerShell support
@@ -55,10 +55,10 @@ COPY --from=builder C:\gradle C:\gradle
 
 # Set environment variables
 ENV GODEBUG=netdns=go
-ENV PATH="C:\bin;C:\jdk\jdk-17.0.8+7\bin;C:\maven\apache-maven-3.9.4\bin;C:\gradle\gradle-8.3\bin;C:\Windows\System32;C:\Windows;C:\Program Files\PowerShell"
-ENV JAVA_HOME="C:\jdk\jdk-17.0.8+7"
-ENV MAVEN_HOME="C:\maven\apache-maven-3.9.4"
-ENV GRADLE_HOME="C:\gradle\gradle-8.3"
+ENV PATH="C:\bin;C:\jdk\jdk-17.0.13+11\bin;C:\maven\apache-maven-3.9.11\bin;C:\gradle\gradle-8.13\bin;C:\Windows\System32;C:\Windows;C:\Program Files\PowerShell"
+ENV JAVA_HOME="C:\jdk\jdk-17.0.13+11"
+ENV MAVEN_HOME="C:\maven\apache-maven-3.9.11"
+ENV GRADLE_HOME="C:\gradle\gradle-8.13"
 # Add environment variable to prevent interactive prompts
 ENV CI="true"
 

--- a/docker/Dockerfile.windows.amd64.ltsc2022
+++ b/docker/Dockerfile.windows.amd64.ltsc2022
@@ -5,9 +5,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS builder
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set versions
-ENV JDK_VERSION="17.0.8+7"
-ENV MAVEN_VERSION="3.9.4"
-ENV GRADLE_VERSION="8.3"
+ENV JDK_VERSION="17.0.13+11"
+ENV MAVEN_VERSION="3.9.11"
+ENV GRADLE_VERSION="8.13"
 
 # Create necessary directories
 RUN mkdir C:\bin | Out-Null; `
@@ -24,18 +24,18 @@ COPY docker/cert.windows.pem docker/cacert.pem C:\users\ContainerAdministrator\.
 RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     `
     # Download JFrog CLI
-    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.68.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
+    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.82.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
     `
     # Download and install JDK
-    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.8_7.zip" -OutFile "C:\jdk.zip"; `
+    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jdk_x64_windows_hotspot_17.0.13_11.zip" -OutFile "C:\jdk.zip"; `
     Expand-Archive -Path "C:\jdk.zip" -DestinationPath "C:\jdk"; `
     `
     # Download and install Maven
-    Invoke-WebRequest -Uri https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip -OutFile C:\maven.zip; `
+    Invoke-WebRequest -Uri https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip -OutFile C:\maven.zip; `
     Expand-Archive -Path C:\maven.zip -DestinationPath C:\maven; `
     `
     # Download and install Gradle
-    Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.3-bin.zip" -OutFile "C:\gradle.zip"; `
+    Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.13-bin.zip" -OutFile "C:\gradle.zip"; `
     Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"
 
 # Final image using PowerShell Nanoserver - much smaller base image with PowerShell support
@@ -55,10 +55,10 @@ COPY --from=builder C:\gradle C:\gradle
 
 # Set environment variables
 ENV GODEBUG=netdns=go
-ENV PATH="C:\bin;C:\jdk\jdk-17.0.8+7\bin;C:\maven\apache-maven-3.9.4\bin;C:\gradle\gradle-8.3\bin;C:\Windows\System32;C:\Windows;C:\Program Files\PowerShell"
-ENV JAVA_HOME="C:\jdk\jdk-17.0.8+7"
-ENV MAVEN_HOME="C:\maven\apache-maven-3.9.4"
-ENV GRADLE_HOME="C:\gradle\gradle-8.3"
+ENV PATH="C:\bin;C:\jdk\jdk-17.0.13+11\bin;C:\maven\apache-maven-3.9.11\bin;C:\gradle\gradle-8.13\bin;C:\Windows\System32;C:\Windows;C:\Program Files\PowerShell"
+ENV JAVA_HOME="C:\jdk\jdk-17.0.13+11"
+ENV MAVEN_HOME="C:\maven\apache-maven-3.9.11"
+ENV GRADLE_HOME="C:\gradle\gradle-8.13"
 # Add environment variable to prevent interactive prompts
 ENV CI="true"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/drone/drone-artifactory
 
-go 1.22.7
+go 1.25.4
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 deps:
   run:
-    - curl -fL https://install-cli.jfrog.io | sh /dev/stdin 2.73.2
+    - curl -fL https://install-cli.jfrog.io | sh /dev/stdin 2.82.0
 run:
   binary:
     source: https://github.com/harness/drone-artifactory/releases/download/{{ release }}/plugin-{{ os }}-{{ arch }}.zst

--- a/plugin/gradle.go
+++ b/plugin/gradle.go
@@ -130,7 +130,7 @@ func GetGradlePublishCommand(args Args) ([][]string, error) {
 		errMsg := "AccessToken is not supported for Gradle" +
 			" try username: <username> , password: <access_token> instead"
 		logrus.Println(errMsg)
-		return cmdList, fmt.Errorf(errMsg)
+		return cmdList, fmt.Errorf("%s", errMsg)
 	}
 	rtPublishCommandArgs = append(rtPublishCommandArgs, "--build-name="+args.BuildName)
 	rtPublishCommandArgs = append(rtPublishCommandArgs, "--build-number="+args.BuildNumber)


### PR DESCRIPTION
  ## Summary
  Updates Go, Alpine, JFrog CLI, Gradle, Maven, and JDK to latest versions to address security vulnerabilities.

  ## Changes
  - Upgraded Go from 1.22.7 to 1.25.4
  - Updated Alpine base image from 3.20 to 3.21
  - Upgraded JFrog CLI from 2.73.2 to 2.82.0
  - Updated Gradle from 8.3 to 8.13
  - Updated Maven from 3.9.4 to 3.9.11
  - Updated JDK from 17.0.8+7 to 17.0.13+11
  - Minor error handling improvement in Gradle plugin

  ## Test Plan
  - Verify all builds pass with updated dependencies
  - Confirm security vulnerabilities are resolved

  Fixes: CI-19671