### PR TITLE
fix: [CI-19940]: Fixing Jfrog version for containerless flow

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,4 +3,4 @@ deps:
     - curl -fL https://install-cli.jfrog.io | sh /dev/stdin 2.82.0
 run:
   binary:
-    source: https://github.com/harness/drone-artifactory/releases/download/{{ release }}/plugin-{{ os }}-{{ arch }}.zst
+    source: https://github.com/drone-plugins/drone-artifactory/releases/download/{{ release }}/plugin-{{ os }}-{{ arch }}.zst


### PR DESCRIPTION

## Fix: Update binary source path for containerless flow

### Problem
When using the containerless flow, the CI Manager is configured with:
```yaml
artifactoryUploadConfig:
  name: github.com/harness/drone-artifactory@refs/tags/v1.8.0
```

This causes the cloud step to clone the codebase from that tag, which still contains an outdated [plugin.yml](cci:7://file:///Users/devanshmathur/drone-artifactory/plugin.yml:0:0-0:0) configuration pointing to:
- Binary source: `https://github.com/harness/drone-artifactory/releases/...`
- JFrog CLI version: `2.73.2`

Since recent development has moved to the `drone-plugins` organization, the binary releases are now published there, but the plugin.yml was never updated to reflect this change.

### Root Cause
The repository was migrated from `harness/drone-artifactory` to `drone-plugins/drone-artifactory`, but the [plugin.yml](cci:7://file:///Users/devanshmathur/drone-artifactory/plugin.yml:0:0-0:0) configuration still referenced the old repository path for binary downloads.

### Solution
Updated [plugin.yml](cci:7://file:///Users/devanshmathur/drone-artifactory/plugin.yml:0:0-0:0) to point to the correct binary source:
```yaml
source: https://github.com/drone-plugins/drone-artifactory/releases/download/{{ release }}/plugin-{{ os }}-{{ arch }}.zst
```
