### PR TITLE
feat: [CI-21851]: Adding upload to GCS step

### DIFF
--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -420,6 +420,19 @@ pipeline:
                   when:
                     stageStatus: Success
                     condition: <+codebase.build.type> == "tag"
+              - step:
+                  name: Upload_Binaries_To_GCS
+                  identifier: Upload_Binaries_To_GCS
+                  template:
+                    templateRef: Upload_Binary_GCS_TI
+                    versionLabel: v1
+                    templateInputs:
+                      type: GCSUpload
+                      spec:
+                        sourcePath: /harness/release
+                        target: drone-artifactory/<+trigger.tag>/
+                      when:
+                        condition: <+codebase.build.type> == "tag"
         description: ""
         variables:
           - name: DRONE_REPO_OWNER


### PR DESCRIPTION
This pull request adds a new deployment step to the pipeline configuration. The main change is the introduction of a step to upload binaries to Google Cloud Storage (GCS) when a build is triggered by a tag.

Deployment pipeline enhancement:

* Added a new `Upload_Binaries_To_GCS` step to `.harness/harness.yaml` that uses the `Upload_Binary_GCS_TI` template to upload binaries from `/harness/release` to a GCS bucket under `drone-artifactory/<+trigger.tag>/`, only when the build type is a tag.