### PR TITLE
fix: [CI-23805]: vulnerabilities in harnesssecure/artifactory

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ pool:
 
 steps:
   - name: build
-    image: golang:1.25.11
+    image: golang:1.25.12
     commands:
       - go test ./...
       - sh scripts/build.sh
@@ -27,7 +27,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.25.11
+    image: golang:1.25.12
     commands:
       - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/amd64/plugin'
     environment:
@@ -38,7 +38,7 @@ steps:
           - tag
 
   - name: build-tag
-    image: golang:1.25.11
+    image: golang:1.25.12
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/amd64/plugin'
     environment:
@@ -85,7 +85,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.25.11
+    image: golang:1.25.12
     commands:
       - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm64/plugin'
     environment:
@@ -96,7 +96,7 @@ steps:
           - tag
 
   - name: build-tag
-    image: golang:1.25.11
+    image: golang:1.25.12
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm64/plugin'
     environment:
@@ -143,7 +143,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.25.11
+    image: golang:1.25.12
     commands:
       - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/windows/amd64/plugin'
     environment:
@@ -153,7 +153,7 @@ steps:
         exclude:
           - tag
   - name: build-tag
-    image: golang:1.25.11
+    image: golang:1.25.12
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/windows/amd64/plugin'
     environment:
@@ -199,7 +199,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.25.11
+    image: golang:1.25.12
     commands:
       - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/windows/amd64/plugin'
     environment:
@@ -209,7 +209,7 @@ steps:
         exclude:
           - tag
   - name: build-tag
-    image: golang:1.25.11
+    image: golang:1.25.12
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/windows/amd64/plugin'
     environment:

--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -33,7 +33,7 @@ pipeline:
                   identifier: Run_1
                   spec:
                     connectorRef: Plugins_Docker_Hub_Connector
-                    image: golang:1.25.11
+                    image: golang:1.25.12
                     shell: Sh
                     command: |-
                       go test -cover ./...
@@ -63,7 +63,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/linux/amd64/plugin
                       when:
@@ -76,7 +76,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/linux/amd64/plugin
                       when:
@@ -138,7 +138,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/linux/arm64/plugin
                       when:
@@ -151,7 +151,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/linux/arm64/plugin
                       when:
@@ -291,7 +291,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -buildvcs=false -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -304,7 +304,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -buildvcs=false -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -377,7 +377,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/linux/amd64/plugin
                       when:
@@ -390,7 +390,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/linux/amd64/plugin
                       when:
@@ -470,7 +470,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/linux/arm64/plugin
                       when:
@@ -483,7 +483,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/linux/arm64/plugin
                       when:
@@ -652,7 +652,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -buildvcs=false -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -665,7 +665,7 @@ pipeline:
                       type: Run
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -buildvcs=false -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -731,7 +731,7 @@ pipeline:
                       identifier: Build_Binaries_Branch
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -buildvcs=false -ldflags "-X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -743,7 +743,7 @@ pipeline:
                       identifier: Build_Binaries_TAG
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.11
+                        image: golang:1.25.12
                         shell: Sh
                         command: go build -v -buildvcs=false -ldflags "-X main.version=<+codebase.tag> -X main.build=<+pipeline.sequenceId>" -a -o release/windows/amd64/plugin
                       when:
@@ -835,7 +835,7 @@ pipeline:
                   identifier: Build_Binaries
                   spec:
                     connectorRef: Plugins_Docker_Hub_Connector
-                    image: golang:1.25.11
+                    image: golang:1.25.12
                     shell: Sh
                     command: |-
                       GOOS=linux   GOARCH=amd64 go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/plugin-linux-amd64

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -32,24 +32,14 @@ RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION
     && rm /tmp/gradle.zip \
     && ln -s /opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle
 
-# Patch vulnerable jars bundled in Gradle
-RUN find /opt/gradle -name "jackson-databind-*.jar" -delete \
-    && find /opt/gradle -name "jackson-core-*.jar" -delete \
-    && find /opt/gradle -name "jackson-annotations-*.jar" -delete \
-    && find /opt/gradle -name "bcprov-jdk18on-*.jar" -delete \
-    && find /opt/gradle -name "bcpg-jdk18on-*.jar" -delete \
-    && find /opt/gradle -name "commons-lang3-*.jar" -delete \
-    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-databind-2.21.5.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-core-2.21.5.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-annotations-2.21.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/bcprov-jdk18on-1.85.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/bcpg-jdk18on-1.85.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/commons-lang3-3.18.0.jar
+# Patch vulnerable jars bundled in Gradle (overwrite in place, keep original filenames for classpath compatibility)
+RUN curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-databind-2.16.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-core-2.16.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-annotations-2.16.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/plugins/bcprov-jdk18on-1.78.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/plugins/bcpg-jdk18on-1.78.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/commons-lang3-3.14.0.jar
 
-# Patch vulnerable jars bundled in Maven
-RUN find / -name "plexus-utils-3*.jar" -delete 2>/dev/null; \
-    find / -name "commons-lang-2*.jar" -not -path "*/commons-lang3*" -delete 2>/dev/null; \
-    curl -fsSL https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar -o /usr/share/java/plexus-utils-4.0.3.jar || true
 
 # Install JFrog CLI (CVE-2026-39821: bumped to 2.115.0 for golang.org/x/net/idna improper authentication fix)
 RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.115.0

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -32,8 +32,27 @@ RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION
     && rm /tmp/gradle.zip \
     && ln -s /opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle
 
-# Install JFrog CLI (CVE-2026-39821: bumped to 2.111.0 for golang.org/x/net/idna improper authentication fix)
-RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.111.0
+# Patch vulnerable jars bundled in Gradle
+RUN find /opt/gradle -name "jackson-databind-*.jar" -delete \
+    && find /opt/gradle -name "jackson-core-*.jar" -delete \
+    && find /opt/gradle -name "jackson-annotations-*.jar" -delete \
+    && find /opt/gradle -name "bcprov-jdk18on-*.jar" -delete \
+    && find /opt/gradle -name "bcpg-jdk18on-*.jar" -delete \
+    && find /opt/gradle -name "commons-lang3-*.jar" -delete \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-databind-2.21.5.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-core-2.21.5.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-annotations-2.21.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/bcprov-jdk18on-1.85.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/bcpg-jdk18on-1.85.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/commons-lang3-3.18.0.jar
+
+# Patch vulnerable jars bundled in Maven
+RUN find / -name "plexus-utils-3*.jar" -delete 2>/dev/null; \
+    find / -name "commons-lang-2*.jar" -not -path "*/commons-lang3*" -delete 2>/dev/null; \
+    curl -fsSL https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar -o /usr/share/java/plexus-utils-4.0.3.jar || true
+
+# Install JFrog CLI (CVE-2026-39821: bumped to 2.115.0 for golang.org/x/net/idna improper authentication fix)
+RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.115.0
 RUN mv ./jf /usr/local/bin/jf
 RUN chmod +x /usr/local/bin/jf
 

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -32,24 +32,14 @@ RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION
     && rm /tmp/gradle.zip \
     && ln -s /opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle
 
-# Patch vulnerable jars bundled in Gradle
-RUN find /opt/gradle -name "jackson-databind-*.jar" -delete \
-    && find /opt/gradle -name "jackson-core-*.jar" -delete \
-    && find /opt/gradle -name "jackson-annotations-*.jar" -delete \
-    && find /opt/gradle -name "bcprov-jdk18on-*.jar" -delete \
-    && find /opt/gradle -name "bcpg-jdk18on-*.jar" -delete \
-    && find /opt/gradle -name "commons-lang3-*.jar" -delete \
-    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-databind-2.21.5.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-core-2.21.5.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-annotations-2.21.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/bcprov-jdk18on-1.85.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/bcpg-jdk18on-1.85.jar \
-    && curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/commons-lang3-3.18.0.jar
+# Patch vulnerable jars bundled in Gradle (overwrite in place, keep original filenames for classpath compatibility)
+RUN curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-databind-2.16.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-core-2.16.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-annotations-2.16.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/plugins/bcprov-jdk18on-1.78.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/plugins/bcpg-jdk18on-1.78.1.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/commons-lang3-3.14.0.jar
 
-# Patch vulnerable jars bundled in Maven
-RUN find / -name "plexus-utils-3*.jar" -delete 2>/dev/null; \
-    find / -name "commons-lang-2*.jar" -not -path "*/commons-lang3*" -delete 2>/dev/null; \
-    curl -fsSL https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar -o /usr/share/java/plexus-utils-4.0.3.jar || true
 
 # Install JFrog CLI (CVE-2026-39821: bumped to 2.115.0 for golang.org/x/net/idna improper authentication fix)
 RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.115.0

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -32,8 +32,27 @@ RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION
     && rm /tmp/gradle.zip \
     && ln -s /opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle
 
-# Install JFrog CLI (CVE-2026-39821: bumped to 2.111.0 for golang.org/x/net/idna improper authentication fix)
-RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.111.0
+# Patch vulnerable jars bundled in Gradle
+RUN find /opt/gradle -name "jackson-databind-*.jar" -delete \
+    && find /opt/gradle -name "jackson-core-*.jar" -delete \
+    && find /opt/gradle -name "jackson-annotations-*.jar" -delete \
+    && find /opt/gradle -name "bcprov-jdk18on-*.jar" -delete \
+    && find /opt/gradle -name "bcpg-jdk18on-*.jar" -delete \
+    && find /opt/gradle -name "commons-lang3-*.jar" -delete \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-databind-2.21.5.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-core-2.21.5.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/jackson-annotations-2.21.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/bcprov-jdk18on-1.85.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/bcpg-jdk18on-1.85.jar \
+    && curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o /opt/gradle/gradle-${GRADLE_VERSION}/lib/commons-lang3-3.18.0.jar
+
+# Patch vulnerable jars bundled in Maven
+RUN find / -name "plexus-utils-3*.jar" -delete 2>/dev/null; \
+    find / -name "commons-lang-2*.jar" -not -path "*/commons-lang3*" -delete 2>/dev/null; \
+    curl -fsSL https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar -o /usr/share/java/plexus-utils-4.0.3.jar || true
+
+# Install JFrog CLI (CVE-2026-39821: bumped to 2.115.0 for golang.org/x/net/idna improper authentication fix)
+RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.115.0
 RUN mv ./jf /usr/local/bin/jf
 RUN chmod +x /usr/local/bin/jf
 

--- a/docker/Dockerfile.windows.amd64.1809
+++ b/docker/Dockerfile.windows.amd64.1809
@@ -38,24 +38,14 @@ RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.13-bin.zip" -OutFile "C:\gradle.zip"; `
     Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"; `
     `
-    # Patch vulnerable jars bundled in Gradle
-    Remove-Item C:\gradle\gradle-8.13\lib\jackson-databind-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\jackson-core-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\jackson-annotations-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\bcprov-jdk18on-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\bcpg-jdk18on-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\commons-lang3-*.jar -Force; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-databind-2.21.5.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-core-2.21.5.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-annotations-2.21.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcprov-jdk18on-1.85.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcpg-jdk18on-1.85.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar" -OutFile "C:\gradle\gradle-8.13\lib\commons-lang3-3.18.0.jar"
+    # Patch vulnerable jars bundled in Gradle (overwrite in place, keep original filenames for classpath compatibility)
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-databind-2.16.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-core-2.16.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-annotations-2.16.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\plugins\bcprov-jdk18on-1.78.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\plugins\bcpg-jdk18on-1.78.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar" -OutFile "C:\gradle\gradle-8.13\lib\commons-lang3-3.14.0.jar"
 
-# Patch vulnerable jars bundled in Maven
-RUN Remove-Item C:\maven\apache-maven-3.9.11\lib\plexus-utils-*.jar -Force -ErrorAction SilentlyContinue; `
-    Remove-Item C:\maven\apache-maven-3.9.11\lib\commons-lang-2*.jar -Force -ErrorAction SilentlyContinue; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar" -OutFile "C:\maven\apache-maven-3.9.11\lib\plexus-utils-4.0.3.jar"
 
 # Final image using PowerShell Nanoserver - much smaller base image with PowerShell support
 FROM mcr.microsoft.com/powershell:7.3-nanoserver-1809

--- a/docker/Dockerfile.windows.amd64.1809
+++ b/docker/Dockerfile.windows.amd64.1809
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS builder
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set versions
-ENV JDK_VERSION="17.0.13+11"
+ENV JDK_VERSION="17.0.19+10"
 ENV MAVEN_VERSION="3.9.11"
 ENV GRADLE_VERSION="8.13"
 
@@ -23,11 +23,11 @@ COPY docker/cert.windows.pem docker/cacert.pem C:\users\ContainerAdministrator\.
 # Generate CA certificates and download/install tools in a single layer
 RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     `
-    # Download JFrog CLI (CVE-2026-39821: bumped to 2.111.0 for golang.org/x/net/idna improper authentication fix)
-    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.111.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
+    # Download JFrog CLI (CVE-2026-39821: bumped to 2.115.0 for golang.org/x/net/idna improper authentication fix)
+    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.115.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
     `
     # Download and install JDK
-    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jdk_x64_windows_hotspot_17.0.13_11.zip" -OutFile "C:\jdk.zip"; `
+    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.19_10.zip" -OutFile "C:\jdk.zip"; `
     Expand-Archive -Path "C:\jdk.zip" -DestinationPath "C:\jdk"; `
     `
     # Download and install Maven
@@ -36,7 +36,26 @@ RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     `
     # Download and install Gradle
     Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.13-bin.zip" -OutFile "C:\gradle.zip"; `
-    Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"
+    Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"; `
+    `
+    # Patch vulnerable jars bundled in Gradle
+    Remove-Item C:\gradle\gradle-8.13\lib\jackson-databind-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\jackson-core-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\jackson-annotations-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\bcprov-jdk18on-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\bcpg-jdk18on-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\commons-lang3-*.jar -Force; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-databind-2.21.5.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-core-2.21.5.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-annotations-2.21.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcprov-jdk18on-1.85.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcpg-jdk18on-1.85.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar" -OutFile "C:\gradle\gradle-8.13\lib\commons-lang3-3.18.0.jar"
+
+# Patch vulnerable jars bundled in Maven
+RUN Remove-Item C:\maven\apache-maven-3.9.11\lib\plexus-utils-*.jar -Force -ErrorAction SilentlyContinue; `
+    Remove-Item C:\maven\apache-maven-3.9.11\lib\commons-lang-2*.jar -Force -ErrorAction SilentlyContinue; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar" -OutFile "C:\maven\apache-maven-3.9.11\lib\plexus-utils-4.0.3.jar"
 
 # Final image using PowerShell Nanoserver - much smaller base image with PowerShell support
 FROM mcr.microsoft.com/powershell:7.3-nanoserver-1809
@@ -55,8 +74,8 @@ COPY --from=builder C:\gradle C:\gradle
 
 # Set environment variables
 ENV GODEBUG=netdns=go
-ENV PATH="C:\bin;C:\jdk\jdk-17.0.13+11\bin;C:\maven\apache-maven-3.9.11\bin;C:\gradle\gradle-8.13\bin;C:\Windows\System32;C:\Windows;C:\Program Files\PowerShell"
-ENV JAVA_HOME="C:\jdk\jdk-17.0.13+11"
+ENV PATH="C:\bin;C:\jdk\jdk-17.0.19+10\bin;C:\maven\apache-maven-3.9.11\bin;C:\gradle\gradle-8.13\bin;C:\Windows\System32;C:\Windows;C:\Program Files\PowerShell"
+ENV JAVA_HOME="C:\jdk\jdk-17.0.19+10"
 ENV MAVEN_HOME="C:\maven\apache-maven-3.9.11"
 ENV GRADLE_HOME="C:\gradle\gradle-8.13"
 # Add environment variable to prevent interactive prompts

--- a/docker/Dockerfile.windows.amd64.ltsc2022
+++ b/docker/Dockerfile.windows.amd64.ltsc2022
@@ -38,24 +38,14 @@ RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.13-bin.zip" -OutFile "C:\gradle.zip"; `
     Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"; `
     `
-    # Patch vulnerable jars bundled in Gradle
-    Remove-Item C:\gradle\gradle-8.13\lib\jackson-databind-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\jackson-core-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\jackson-annotations-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\bcprov-jdk18on-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\bcpg-jdk18on-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\commons-lang3-*.jar -Force; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-databind-2.21.5.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-core-2.21.5.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-annotations-2.21.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcprov-jdk18on-1.85.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcpg-jdk18on-1.85.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar" -OutFile "C:\gradle\gradle-8.13\lib\commons-lang3-3.18.0.jar"
+    # Patch vulnerable jars bundled in Gradle (overwrite in place, keep original filenames for classpath compatibility)
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-databind-2.16.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-core-2.16.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-annotations-2.16.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\plugins\bcprov-jdk18on-1.78.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\plugins\bcpg-jdk18on-1.78.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar" -OutFile "C:\gradle\gradle-8.13\lib\commons-lang3-3.14.0.jar"
 
-# Patch vulnerable jars bundled in Maven
-RUN Remove-Item C:\maven\apache-maven-3.9.11\lib\plexus-utils-*.jar -Force -ErrorAction SilentlyContinue; `
-    Remove-Item C:\maven\apache-maven-3.9.11\lib\commons-lang-2*.jar -Force -ErrorAction SilentlyContinue; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar" -OutFile "C:\maven\apache-maven-3.9.11\lib\plexus-utils-4.0.3.jar"
 
 # Final image using PowerShell Nanoserver - much smaller base image with PowerShell support
 FROM mcr.microsoft.com/powershell:7.3-nanoserver-ltsc2022

--- a/docker/Dockerfile.windows.amd64.ltsc2022
+++ b/docker/Dockerfile.windows.amd64.ltsc2022
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS builder
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set versions
-ENV JDK_VERSION="17.0.13+11"
+ENV JDK_VERSION="17.0.19+10"
 ENV MAVEN_VERSION="3.9.11"
 ENV GRADLE_VERSION="8.13"
 
@@ -23,11 +23,11 @@ COPY docker/cert.windows.pem docker/cacert.pem C:\users\ContainerAdministrator\.
 # Generate CA certificates and download/install tools in a single layer
 RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     `
-    # Download JFrog CLI (CVE-2026-39821: bumped to 2.111.0 for golang.org/x/net/idna improper authentication fix)
-    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.111.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
+    # Download JFrog CLI (CVE-2026-39821: bumped to 2.115.0 for golang.org/x/net/idna improper authentication fix)
+    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.115.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
     `
     # Download and install JDK
-    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jdk_x64_windows_hotspot_17.0.13_11.zip" -OutFile "C:\jdk.zip"; `
+    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.19_10.zip" -OutFile "C:\jdk.zip"; `
     Expand-Archive -Path "C:\jdk.zip" -DestinationPath "C:\jdk"; `
     `
     # Download and install Maven
@@ -36,7 +36,26 @@ RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     `
     # Download and install Gradle
     Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.13-bin.zip" -OutFile "C:\gradle.zip"; `
-    Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"
+    Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"; `
+    `
+    # Patch vulnerable jars bundled in Gradle
+    Remove-Item C:\gradle\gradle-8.13\lib\jackson-databind-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\jackson-core-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\jackson-annotations-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\bcprov-jdk18on-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\bcpg-jdk18on-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\commons-lang3-*.jar -Force; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-databind-2.21.5.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-core-2.21.5.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-annotations-2.21.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcprov-jdk18on-1.85.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcpg-jdk18on-1.85.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar" -OutFile "C:\gradle\gradle-8.13\lib\commons-lang3-3.18.0.jar"
+
+# Patch vulnerable jars bundled in Maven
+RUN Remove-Item C:\maven\apache-maven-3.9.11\lib\plexus-utils-*.jar -Force -ErrorAction SilentlyContinue; `
+    Remove-Item C:\maven\apache-maven-3.9.11\lib\commons-lang-2*.jar -Force -ErrorAction SilentlyContinue; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar" -OutFile "C:\maven\apache-maven-3.9.11\lib\plexus-utils-4.0.3.jar"
 
 # Final image using PowerShell Nanoserver - much smaller base image with PowerShell support
 FROM mcr.microsoft.com/powershell:7.3-nanoserver-ltsc2022
@@ -55,8 +74,8 @@ COPY --from=builder C:\gradle C:\gradle
 
 # Set environment variables
 ENV GODEBUG=netdns=go
-ENV PATH="C:\bin;C:\jdk\jdk-17.0.13+11\bin;C:\maven\apache-maven-3.9.11\bin;C:\gradle\gradle-8.13\bin;C:\Windows\System32;C:\Windows;C:\Program Files\PowerShell"
-ENV JAVA_HOME="C:\jdk\jdk-17.0.13+11"
+ENV PATH="C:\bin;C:\jdk\jdk-17.0.19+10\bin;C:\maven\apache-maven-3.9.11\bin;C:\gradle\gradle-8.13\bin;C:\Windows\System32;C:\Windows;C:\Program Files\PowerShell"
+ENV JAVA_HOME="C:\jdk\jdk-17.0.19+10"
 ENV MAVEN_HOME="C:\maven\apache-maven-3.9.11"
 ENV GRADLE_HOME="C:\gradle\gradle-8.13"
 # Add environment variable to prevent interactive prompts

--- a/docker/Dockerfile.windows.amd64.ltsc2025
+++ b/docker/Dockerfile.windows.amd64.ltsc2025
@@ -44,24 +44,14 @@ RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.13-bin.zip" -OutFile "C:\gradle.zip"; `
     Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"; `
     `
-    # Patch vulnerable jars bundled in Gradle
-    Remove-Item C:\gradle\gradle-8.13\lib\jackson-databind-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\jackson-core-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\jackson-annotations-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\bcprov-jdk18on-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\bcpg-jdk18on-*.jar -Force; `
-    Remove-Item C:\gradle\gradle-8.13\lib\commons-lang3-*.jar -Force; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-databind-2.21.5.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-core-2.21.5.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-annotations-2.21.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcprov-jdk18on-1.85.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcpg-jdk18on-1.85.jar"; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar" -OutFile "C:\gradle\gradle-8.13\lib\commons-lang3-3.18.0.jar"
+    # Patch vulnerable jars bundled in Gradle (overwrite in place, keep original filenames for classpath compatibility)
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-databind-2.16.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-core-2.16.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-annotations-2.16.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\plugins\bcprov-jdk18on-1.78.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\plugins\bcpg-jdk18on-1.78.1.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar" -OutFile "C:\gradle\gradle-8.13\lib\commons-lang3-3.14.0.jar"
 
-# Patch vulnerable jars bundled in Maven
-RUN Remove-Item C:\maven\apache-maven-3.9.11\lib\plexus-utils-*.jar -Force -ErrorAction SilentlyContinue; `
-    Remove-Item C:\maven\apache-maven-3.9.11\lib\commons-lang-2*.jar -Force -ErrorAction SilentlyContinue; `
-    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar" -OutFile "C:\maven\apache-maven-3.9.11\lib\plexus-utils-4.0.3.jar"
 
 # Stage 2: PowerShell 7 installer stage.
 # nanoserver:ltsc2025 does not ship PowerShell, and there is no

--- a/docker/Dockerfile.windows.amd64.ltsc2025
+++ b/docker/Dockerfile.windows.amd64.ltsc2025
@@ -11,9 +11,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2025 AS builder
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set versions (unchanged from ltsc2022 sibling)
-ENV JDK_VERSION="17.0.8+7"
-ENV MAVEN_VERSION="3.9.4"
-ENV GRADLE_VERSION="8.3"
+ENV JDK_VERSION="17.0.19+10"
+ENV MAVEN_VERSION="3.9.11"
+ENV GRADLE_VERSION="8.13"
 
 # Create necessary directories
 RUN mkdir C:\bin | Out-Null; `
@@ -29,20 +29,39 @@ COPY docker/cert.windows.pem docker/cacert.pem C:\users\ContainerAdministrator\.
 # Generate CA certificates and download/install tools in a single layer
 RUN certutil -generateSSTFromWU C:\certificates\ca-certificates.sst; `
     `
-    # Download JFrog CLI
-    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.68.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
+    # Download JFrog CLI (CVE-2026-39821: bumped to 2.115.0 for golang.org/x/net/idna improper authentication fix)
+    Invoke-WebRequest -Uri https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.115.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:\bin\jfrog.exe; `
     `
     # Download and install JDK
-    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.8_7.zip" -OutFile "C:\jdk.zip"; `
+    Invoke-WebRequest -Uri "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.19_10.zip" -OutFile "C:\jdk.zip"; `
     Expand-Archive -Path "C:\jdk.zip" -DestinationPath "C:\jdk"; `
     `
     # Download and install Maven
-    Invoke-WebRequest -Uri https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip -OutFile C:\maven.zip; `
+    Invoke-WebRequest -Uri https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip -OutFile C:\maven.zip; `
     Expand-Archive -Path C:\maven.zip -DestinationPath C:\maven; `
     `
     # Download and install Gradle
-    Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.3-bin.zip" -OutFile "C:\gradle.zip"; `
-    Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"
+    Invoke-WebRequest -Uri "https://services.gradle.org/distributions/gradle-8.13-bin.zip" -OutFile "C:\gradle.zip"; `
+    Expand-Archive -Path "C:\gradle.zip" -DestinationPath "C:\gradle"; `
+    `
+    # Patch vulnerable jars bundled in Gradle
+    Remove-Item C:\gradle\gradle-8.13\lib\jackson-databind-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\jackson-core-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\jackson-annotations-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\bcprov-jdk18on-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\bcpg-jdk18on-*.jar -Force; `
+    Remove-Item C:\gradle\gradle-8.13\lib\commons-lang3-*.jar -Force; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.5/jackson-databind-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-databind-2.21.5.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.5/jackson-core-2.21.5.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-core-2.21.5.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar" -OutFile "C:\gradle\gradle-8.13\lib\jackson-annotations-2.21.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcprov-jdk18on-1.85.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.85/bcpg-jdk18on-1.85.jar" -OutFile "C:\gradle\gradle-8.13\lib\bcpg-jdk18on-1.85.jar"; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar" -OutFile "C:\gradle\gradle-8.13\lib\commons-lang3-3.18.0.jar"
+
+# Patch vulnerable jars bundled in Maven
+RUN Remove-Item C:\maven\apache-maven-3.9.11\lib\plexus-utils-*.jar -Force -ErrorAction SilentlyContinue; `
+    Remove-Item C:\maven\apache-maven-3.9.11\lib\commons-lang-2*.jar -Force -ErrorAction SilentlyContinue; `
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/4.0.3/plexus-utils-4.0.3.jar" -OutFile "C:\maven\apache-maven-3.9.11\lib\plexus-utils-4.0.3.jar"
 
 # Stage 2: PowerShell 7 installer stage.
 # nanoserver:ltsc2025 does not ship PowerShell, and there is no
@@ -83,10 +102,10 @@ COPY --from=installer-env C:\PowerShell C:\PowerShell
 # Note: nanoserver:ltsc2025 does NOT include Windows PowerShell 5.1, so
 # `powershell` will not resolve -- use `pwsh` (PowerShell 7) instead.
 ENV GODEBUG=netdns=go
-ENV PATH="C:\bin;C:\jdk\jdk-17.0.8+7\bin;C:\maven\apache-maven-3.9.4\bin;C:\gradle\gradle-8.3\bin;C:\Windows\System32;C:\Windows;C:\PowerShell"
-ENV JAVA_HOME="C:\jdk\jdk-17.0.8+7"
-ENV MAVEN_HOME="C:\maven\apache-maven-3.9.4"
-ENV GRADLE_HOME="C:\gradle\gradle-8.3"
+ENV PATH="C:\bin;C:\jdk\jdk-17.0.19+10\bin;C:\maven\apache-maven-3.9.11\bin;C:\gradle\gradle-8.13\bin;C:\Windows\System32;C:\Windows;C:\PowerShell"
+ENV JAVA_HOME="C:\jdk\jdk-17.0.19+10"
+ENV MAVEN_HOME="C:\maven\apache-maven-3.9.11"
+ENV GRADLE_HOME="C:\gradle\gradle-8.13"
 # Add environment variable to prevent interactive prompts
 ENV CI="true"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/drone/drone-artifactory
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 deps:
   run:
-    - curl -fL https://install-cli.jfrog.io | sh /dev/stdin 2.111.0
+    - curl -fL https://install-cli.jfrog.io | sh /dev/stdin 2.115.0
 run:
   binary:
     source: https://github.com/drone-plugins/drone-artifactory/releases/download/{{ release }}/plugin-{{ os }}-{{ arch }}.zst


### PR DESCRIPTION
## Vulnerability Remediation: harnesssecure/artifactory

**Team:** CI (Harness CI Platform)
**Tickets:** [CI-23805](https://harness.atlassian.net/browse/CI-23805)
**Test image:** `saurabhharness/artifactory-test:artifactory-1.9.1--v5`

**On-Demand scanner runs (Harness https://harness0.harness.io/):**
- Baseline: [20Ybxqg9TaGXsv_n4TdRbQ](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/20Ybxqg9TaGXsv_n4TdRbQ/security)
- After: [135_jfSQT82L_f9kfKlsYQ](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/135_jfSQT82L_f9kfKlsYQ/security)

## Changes
| Change | Why |
|----------------------|--------|
| go.mod → Go 1.25.12 | Fixes Go stdlib CVEs (the Go version in go.mod determines which stdlib ships with the binary) |
| JFrog CLI → 2.115.0 | Fixes golang.org/x/net/idna CVE bundled in the CLI binary |
| JDK → 17.0.19+10 | Fixes Java runtime CVEs |
| Maven → 3.9.11 | Newer Maven, fewer bundled vulnerabilities |
| Gradle jar patch: jackson-databind → 2.21.5 | CVE in Gradle's bundled jackson-databind |
| Gradle jar patch: bcprov/bcpg → 1.85 | CVEs in Gradle's bundled BouncyCastle crypto library |
| Gradle jar patch: commons-lang3 → 3.18.0 | CVE in Gradle's bundled commons-lang3 |
| Maven jar patch: plexus-utils → 4.0.3 | CVE in Maven's bundled plexus-utils |
| LTSC2025 Dockerfile rewrite | Was severely outdated (JDK 17.0.8, Maven 3.9.4, Gradle 8.3, JFrog CLI 2.68.0) — brought in line with the other Dockerfiles |

[CI-23805]: https://harness.atlassian.net/browse/CI-23805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ